### PR TITLE
Delete in details

### DIFF
--- a/components/DeleteConfirmation/index.js
+++ b/components/DeleteConfirmation/index.js
@@ -5,7 +5,6 @@ import Router, { useRouter } from "next/router";
 
 const StyledDeleteIcon = styled.button`
   width: 15%;
-  padding-block: 10px;
   border: none;
   background-color: transparent;
   &:hover {

--- a/components/DeleteConfirmation/index.js
+++ b/components/DeleteConfirmation/index.js
@@ -1,0 +1,79 @@
+import styled from "styled-components";
+import { StyledSubmitButton, StyledCancelButton } from "../Buttons";
+import { useReducer, useState } from "react";
+import Router, { useRouter } from "next/router";
+
+const StyledDeleteIcon = styled.button`
+  width: 15%;
+  padding-block: 10px;
+  border: none;
+  background-color: transparent;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+const StyledDeleteConfirmation = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  column-gap: 5px;
+  padding: 5px;
+`;
+const StyledConfirmButton = styled(StyledSubmitButton)`
+  width: auto;
+  display: flex;
+  justify-content: center;
+  margin: 0px;
+  font-size: 14px;
+  padding: 5px 10px;
+  background-color: var(--deleteColor);
+  &:hover {
+    background-color: darkred;
+  }
+`;
+const StyledSmallCancelButton = styled(StyledCancelButton)`
+  width: auto;
+  display: flex;
+  justify-content: center;
+  margin: 0px;
+  font-size: 14px;
+  padding: 5px 10px;
+`;
+
+export default function DeleteConfirmation({
+  product,
+  onDeleteProduct,
+  backToList,
+}) {
+  const [showConfirmButtons, setShowConfirmButtons] = useState(false);
+  const router = useRouter();
+  return (
+    <>
+      <StyledDeleteIcon
+        type="button"
+        onClick={() => setShowConfirmButtons(true)}
+        disabled={showConfirmButtons}
+      >
+        ✖️
+      </StyledDeleteIcon>
+      {showConfirmButtons && (
+        <StyledDeleteConfirmation>
+          <StyledSmallCancelButton
+            type="button"
+            onClick={() => setShowConfirmButtons(false)}
+          >
+            Cancel
+          </StyledSmallCancelButton>{" "}
+          <StyledConfirmButton
+            type="button"
+            onClick={() => {
+              backToList && router.push("/");
+              onDeleteProduct(product._id);
+            }}
+          >
+            Confirm
+          </StyledConfirmButton>
+        </StyledDeleteConfirmation>
+      )}
+    </>
+  );
+}

--- a/components/DeleteConfirmation/index.js
+++ b/components/DeleteConfirmation/index.js
@@ -1,10 +1,10 @@
 import styled from "styled-components";
 import { StyledSubmitButton, StyledCancelButton } from "../Buttons";
-import { useReducer, useState } from "react";
-import Router, { useRouter } from "next/router";
+import { useState } from "react";
+import { useRouter } from "next/router";
 
 const StyledDeleteIcon = styled.button`
-  width: 15%;
+  width: ${({ $onDetailsPage }) => ($onDetailsPage ? "25%" : "15%")};
   border: none;
   background-color: transparent;
   &:hover {
@@ -37,25 +37,31 @@ const StyledSmallCancelButton = styled(StyledCancelButton)`
   font-size: 14px;
   padding: 5px 10px;
 `;
+const StyledDeleteMessage = styled.span`
+  font-size: 18px;
+  color: var(--primaryDarkColor);
+`;
 
 export default function DeleteConfirmation({
   product,
   onDeleteProduct,
-  backToList,
+  onDetailsPage,
 }) {
   const [showConfirmButtons, setShowConfirmButtons] = useState(false);
   const router = useRouter();
   return (
     <>
       <StyledDeleteIcon
+        $onDetailsPage={onDetailsPage}
         type="button"
         onClick={() => setShowConfirmButtons(true)}
         disabled={showConfirmButtons}
       >
-        ✖️
+        {onDetailsPage && <StyledDeleteMessage>Delete </StyledDeleteMessage>}🗑️
       </StyledDeleteIcon>
       {showConfirmButtons && (
         <StyledDeleteConfirmation>
+          <span>Are you sure to delete?</span>
           <StyledSmallCancelButton
             type="button"
             onClick={() => setShowConfirmButtons(false)}
@@ -65,7 +71,7 @@ export default function DeleteConfirmation({
           <StyledConfirmButton
             type="button"
             onClick={() => {
-              backToList && router.push("/");
+              onDetailsPage && router.push("/");
               onDeleteProduct(product._id);
             }}
           >

--- a/components/ProductListItem/index.js
+++ b/components/ProductListItem/index.js
@@ -1,7 +1,6 @@
 import styled from "styled-components";
 import Link from "next/link";
-import { useState } from "react";
-import { StyledSubmitButton, StyledCancelButton } from "../Buttons";
+import DeleteConfirmation from "../DeleteConfirmation";
 
 const StyledListItem = styled.li`
   margin-block: 7px;
@@ -21,70 +20,12 @@ const StyledLink = styled(Link)`
     cursor: pointer;
   }
 `;
-const StyledDeleteIcon = styled.button`
-  width: 15%;
-  padding-block: 10px;
-  border: none;
-  background-color: transparent;
-  &:hover {
-    cursor: pointer;
-  }
-`;
-const StyledDeleteConfirmation = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  column-gap: 5px;
-  padding: 5px;
-`;
-const StyledConfirmButton = styled(StyledSubmitButton)`
-  width: auto;
-  display: flex;
-  justify-content: center;
-  margin: 0px;
-  font-size: 14px;
-  padding: 5px 10px;
-  background-color: var(--deleteColor);
-  &:hover {
-    background-color: darkred;
-  }
-`;
-const StyledSmallCancelButton = styled(StyledCancelButton)`
-  width: auto;
-  display: flex;
-  justify-content: center;
-  margin: 0px;
-  font-size: 14px;
-  padding: 5px 10px;
-`;
 
 export default function ProductListItem({ product, onDeleteProduct }) {
-  const [showConfirmButtons, setShowConfirmButtons] = useState(false);
   return (
     <StyledListItem>
       <StyledLink href={`/products/${product._id}`}>{product.name} </StyledLink>
-      <StyledDeleteIcon
-        type="button"
-        onClick={() => setShowConfirmButtons(true)}
-        disabled={showConfirmButtons}
-      >
-        ✖️
-      </StyledDeleteIcon>
-      {showConfirmButtons && (
-        <StyledDeleteConfirmation>
-          <StyledSmallCancelButton
-            type="button"
-            onClick={() => setShowConfirmButtons(false)}
-          >
-            Cancel
-          </StyledSmallCancelButton>{" "}
-          <StyledConfirmButton
-            type="button"
-            onClick={() => onDeleteProduct(product._id)}
-          >
-            Confirm
-          </StyledConfirmButton>
-        </StyledDeleteConfirmation>
-      )}
+      <DeleteConfirmation product={product} onDeleteProduct={onDeleteProduct} />
     </StyledListItem>
   );
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,7 +37,7 @@ export default function App({ Component, pageProps }) {
         stores={stores}
         onAddProduct={handleAddProduct}
         onEditProduct={handleEditProduct}
-        handleDeleteProduct={handleDeleteProduct}
+        onDeleteProduct={handleDeleteProduct}
       />
     </>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,7 +17,7 @@ const StyledCreateLink = styled(Link)`
   text-decoration: none;
   background-color: var(--accentColor);
   border-radius: 50px;
-  box-shadow: 0px 1px 3px var(--primaryFontColor);
+  box-shadow: 0px 1px 3px var(--primaryDarkColor);
   &:hover {
     bottom: 47.5px;
     right: 47.5px;

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,11 +26,11 @@ const StyledCreateLink = styled(Link)`
   }
 `;
 
-export default function HomePage({ products, handleDeleteProduct }) {
+export default function HomePage({ products, onDeleteProduct }) {
   return (
     <main>
       <ProductsList
-        onDeleteProduct={handleDeleteProduct}
+        onDeleteProduct={onDeleteProduct}
         products={products}
       ></ProductsList>
       <StyledCreateLink href="/create">+</StyledCreateLink>

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -13,7 +13,7 @@ const StyledTitleContainer = styled.div`
 `;
 
 const StyledTitle = styled.h2`
-  width: 85%;
+  width: 75%;
   margin: 0px;
 `;
 
@@ -123,7 +123,7 @@ export default function ProductDetailsPage({
             <DeleteConfirmation
               product={product}
               onDeleteProduct={onDeleteProduct}
-              backToList
+              onDetailsPage
             />
           </StyledTitleContainer>
           <StyledDetailTitle>Store</StyledDetailTitle>

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -5,6 +5,18 @@ import styled from "styled-components";
 import { StyledCancelButton, StyledSubmitButton } from "@/components/Buttons";
 import DeleteConfirmation from "@/components/DeleteConfirmation";
 
+const StyledTitleContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  margin-block: 20px;
+`;
+
+const StyledTitle = styled.h2`
+  width: 85%;
+  margin: 0px;
+`;
+
 const StyledDetailField = styled.p`
   width: 100%;
   background-color: var(--secondaryBackgroundColor);
@@ -17,21 +29,21 @@ const StyledDetailTitle = styled.h3`
   margin-block: 0px 0px;
 `;
 
-const StyledLinkButton = styled(Link)`
-  display: inline-block;
-  padding: 10px 40px;
-  background-color: var(--primaryDarkColor);
-  color: white;
-  text-decoration: none;
-  margin-top: 40px;
-  border-radius: 5px;
-  box-shadow: 0px 1px 3px var(--primaryDarkColor);
-  &:hover {
-    color: var(--accentColor);
-    background-color: black;
-    cursor: pointer;
-  }
-`;
+// const StyledLinkButton = styled(Link)`
+//   display: inline-block;
+//   padding: 10px 40px;
+//   background-color: var(--primaryDarkColor);
+//   color: white;
+//   text-decoration: none;
+//   margin-top: 40px;
+//   border-radius: 5px;
+//   box-shadow: 0px 1px 3px var(--primaryDarkColor);
+//   &:hover {
+//     color: var(--accentColor);
+//     background-color: black;
+//     cursor: pointer;
+//   }
+// `;
 
 const StyledForm = styled.form`
   display: flex;
@@ -122,12 +134,14 @@ export default function ProductDetailsPage({
     <main>
       {!isEdit ? (
         <>
-          <h2>{product.name}</h2>
-          <DeleteConfirmation
-            product={product}
-            onDeleteProduct={onDeleteProduct}
-            backToList
-          />
+          <StyledTitleContainer>
+            <StyledTitle>{product.name}</StyledTitle>
+            <DeleteConfirmation
+              product={product}
+              onDeleteProduct={onDeleteProduct}
+              backToList
+            />
+          </StyledTitleContainer>
           <StyledDetailTitle>Store</StyledDetailTitle>
           <StyledDetailField>
             {linkedStore ? linkedStore.name : "No Store selected"}

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useState } from "react";
 import styled from "styled-components";
 import { StyledCancelButton, StyledSubmitButton } from "@/components/Buttons";
+import DeleteConfirmation from "@/components/DeleteConfirmation";
 
 const StyledDetailField = styled.p`
   width: 100%;
@@ -84,6 +85,7 @@ export default function ProductDetailsPage({
   products,
   stores,
   onEditProduct,
+  onDeleteProduct,
 }) {
   const router = useRouter();
   const { isReady } = router;
@@ -92,6 +94,7 @@ export default function ProductDetailsPage({
   const [isEdit, setIsEdit] = useState(false);
 
   const product = products.find((product) => product._id === id);
+  if (!product) return <h2>product not found</h2>;
   if (!isReady) return <h2>is Loading</h2>;
 
   const linkedStore = stores.find(
@@ -120,6 +123,11 @@ export default function ProductDetailsPage({
       {!isEdit ? (
         <>
           <h2>{product.name}</h2>
+          <DeleteConfirmation
+            product={product}
+            onDeleteProduct={onDeleteProduct}
+            backToList
+          />
           <StyledDetailTitle>Store</StyledDetailTitle>
           <StyledDetailField>
             {linkedStore ? linkedStore.name : "No Store selected"}

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -29,22 +29,6 @@ const StyledDetailTitle = styled.h3`
   margin-block: 0px 0px;
 `;
 
-// const StyledLinkButton = styled(Link)`
-//   display: inline-block;
-//   padding: 10px 40px;
-//   background-color: var(--primaryDarkColor);
-//   color: white;
-//   text-decoration: none;
-//   margin-top: 40px;
-//   border-radius: 5px;
-//   box-shadow: 0px 1px 3px var(--primaryDarkColor);
-//   &:hover {
-//     color: var(--accentColor);
-//     background-color: black;
-//     cursor: pointer;
-//   }
-// `;
-
 const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
@@ -191,7 +175,7 @@ export default function ProductDetailsPage({
             defaultValue={product.note}
           ></StyledTextArea>
           <StyledButtonContainer>
-            <StyledCancelButton onClick={() => setIsEdit(false)}>
+            <StyledCancelButton type="button" onClick={() => setIsEdit(false)}>
               Cancel
             </StyledCancelButton>
             <StyledSubmitButton type="submit">Save</StyledSubmitButton>


### PR DESCRIPTION
This PR enables the user 
- to delete a product from within the details page. 
- to confirm or cancel the delete-process.

Please be aware, that the wireframes from this user story don't match the actual design for this PR anymore. We adapted / improved the design. The functionality is the same though. 